### PR TITLE
app: add input debouncing for table selection

### DIFF
--- a/rql/src/app.rs
+++ b/rql/src/app.rs
@@ -319,12 +319,14 @@ impl App {
                 if let Some(action) = self.bindings.matches(self.focus, key) {
                     match action {
                         Action::TablesNext => {
-                            self.tables.next();
-                            self.open_table();
+                            if self.tables.next() {
+                                self.open_table();
+                            }
                         }
                         Action::TablesPrev => {
-                            self.tables.previous();
-                            self.open_table();
+                            if self.tables.previous() {
+                                self.open_table();
+                            }
                         }
                         Action::TableNext => {
                             let table_rows = self.num_table_rows();

--- a/rql/src/tables.rs
+++ b/rql/src/tables.rs
@@ -19,22 +19,30 @@ impl DbTables {
         self.names.iter().map(|s| s.len() as u16).max().unwrap_or(0)
     }
 
-    pub fn next(&mut self) {
+    /// next selects the subsequent table in the list, returning whether it changed
+    pub fn next(&mut self) -> bool {
         let i = self
             .state
             .selected()
             .map(|i| if i >= self.names.len() - 1 { 0 } else { i + 1 })
             .unwrap_or(0);
+        let changed = !self.state.selected().is_some_and(|last| last == i);
         self.state.select(Some(i));
+
+        changed
     }
 
-    pub fn previous(&mut self) {
+    /// previous returns the prior table in the list, returning whether it changed
+    pub fn previous(&mut self) -> bool {
         let i = self
             .state
             .selected()
             .map(|i| if i == 0 { self.names.len() - 1 } else { i - 1 })
             .unwrap_or(0);
+        let changed = !self.state.selected().is_some_and(|last| last == i);
         self.state.select(Some(i));
+
+        changed
     }
 
     pub fn selected(&self) -> Option<String> {


### PR DESCRIPTION
Not realizing that the table name was selected, I'd hold down on command launch. Down wraps to the top table; the only one in my large test database. Which then queues up a refetch and rerender. The buffer size for this appears large and makes the app hang for tens of seconds.

Individually, the fetch and render are still fast.

I added a debounce function to determine if the same table is being fetched again. If one wanted to refresh a single table database, this'll break that behavior by scrolling through names.