### PR TITLE
rql: fallback to errors on stdout w/o logging

### DIFF
--- a/rql/src/bin/rql.rs
+++ b/rql/src/bin/rql.rs
@@ -1,4 +1,5 @@
 use std::{fmt::Debug, path::Path};
+use tracing_subscriber::{filter::LevelFilter, prelude::*};
 
 use rql::prelude::*;
 
@@ -48,7 +49,13 @@ fn init_tracing(args: &Args) -> Result<()> {
             .with_writer(log_file)
             .with_env_filter(filter)
             .init();
+    } else {
+        // provide users something when a fatal error occurs
+        tracing_subscriber::registry()
+            .with(tracing_subscriber::fmt::layer().with_filter(LevelFilter::ERROR))
+            .init();
     }
+
     Ok(())
 }
 


### PR DESCRIPTION
At least a few times now, I've invoked the command with a typo in the path.
Without logging configured it'll just exit 1 with no output.

error is only used for fatal errors top-level. I propose that when
logging isn't configured, it should fall back to logging errors to
stdout.

![image](https://github.com/collinvandyck/rust-learning/assets/4763746/18c4ab82-2b88-43a6-8c90-f82695cb8cca)
