### PR TITLE
rql: add search functionality

### DIFF
--- a/rql/Cargo.lock
+++ b/rql/Cargo.lock
@@ -1132,6 +1132,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "tracing-test",
 ]
 
 [[package]]
@@ -1816,6 +1817,29 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a2c0ff408fe918a94c428a3f2ad04e4afd5c95bbc08fcf868eff750c15728a4"
+dependencies = [
+ "lazy_static",
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258bc1c4f8e2e73a977812ab339d503e6feeb92700f6d07a6de4d321522d5c08"
+dependencies = [
+ "lazy_static",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/rql/Cargo.toml
+++ b/rql/Cargo.toml
@@ -17,3 +17,6 @@ tokio = { version = "1.32.0", features = ["full"] }
 tracing = "0.1.37"
 tracing-appender = "0.2.2"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "fmt"] }
+
+[dev-dependencies]
+tracing-test = "0.2.4"

--- a/rql/src/app.rs
+++ b/rql/src/app.rs
@@ -175,40 +175,42 @@ impl App {
             let help = {
                 let no_style = Style::default();
                 let key_style = Style::default().fg(Color::LightCyan);
-
-                if self.focus == Focus::Search {
-                    let mut nav = vec![
-                        Span::styled("Esc", key_style),
-                        Span::raw(": exit search | "),
-                        Span::styled("Enter", key_style),
-                        Span::raw(": navigate results || current query: "),
-                    ];
-                    if let Some(q) = self.search.value.as_ref() {
-                        nav.push(Span::styled(q, search_title_style));
-                    }
-                    nav
-                } else {
-                    let mut nav = ["j", "k", "h", "l", "↓", "↑", "←", "→"]
-                        .iter()
-                        .zip(std::iter::repeat(Span::styled(",", no_style)))
-                        .map(|(s, sep)| [sep, Span::styled(*s, key_style)])
-                        .flatten()
-                        .skip(1)
-                        .collect::<Vec<_>>();
-                    nav.push(Span::raw(": navigate | "));
-                    nav.append(
-                        &mut ["q", "esc"]
+                match self.focus {
+                    Focus::Tables | Focus::Table => {
+                        let mut nav = ["j", "k", "h", "l", "↓", "↑", "←", "→"]
                             .iter()
                             .zip(std::iter::repeat(Span::styled(",", no_style)))
                             .map(|(s, sep)| [sep, Span::styled(*s, key_style)])
                             .flatten()
                             .skip(1)
-                            .collect::<Vec<_>>(),
-                    );
-                    nav.push(Span::raw(": back/quit | "));
-                    nav.push(Span::styled("/", key_style));
-                    nav.push(Span::raw(": search"));
-                    nav
+                            .collect::<Vec<_>>();
+                        nav.push(Span::raw(": navigate | "));
+                        nav.append(
+                            &mut ["q", "esc"]
+                                .iter()
+                                .zip(std::iter::repeat(Span::styled(",", no_style)))
+                                .map(|(s, sep)| [sep, Span::styled(*s, key_style)])
+                                .flatten()
+                                .skip(1)
+                                .collect::<Vec<_>>(),
+                        );
+                        nav.push(Span::raw(": back/quit | "));
+                        nav.push(Span::styled("/", key_style));
+                        nav.push(Span::raw(": search"));
+                        nav
+                    }
+                    Focus::Search => {
+                        let mut nav = vec![
+                            Span::styled("Esc", key_style),
+                            Span::raw(": exit search | "),
+                            Span::styled("Enter", key_style),
+                            Span::raw(": navigate results || current query: "),
+                        ];
+                        if let Some(q) = self.search.value.as_ref() {
+                            nav.push(Span::styled(q, search_title_style));
+                        }
+                        nav
+                    }
                 }
             };
             let help = text::Line::from(help);

--- a/rql/src/app.rs
+++ b/rql/src/app.rs
@@ -263,6 +263,11 @@ impl App {
     fn draw_help(&mut self) -> Paragraph {
         let no_style = Style::default();
         let key_style = Style::default().fg(Color::LightCyan);
+        let search_style = if self.search.is_some() {
+            Style::default().fg(Color::Green)
+        } else {
+            no_style
+        };
         let help = match self.focus {
             Focus::Tables | Focus::Table => {
                 Self::intersperse_keys(&["j", "k", "h", "l", "↓", "↑", "←", "→"], key_style)
@@ -271,7 +276,8 @@ impl App {
                     .chain(vec![
                         Span::raw(": back/quit | "),
                         Span::styled("/", key_style),
-                        Span::raw(": search"),
+                        Span::raw(": "),
+                        Span::styled("search", search_style),
                     ])
                     .collect()
             }

--- a/rql/src/app.rs
+++ b/rql/src/app.rs
@@ -157,18 +157,22 @@ impl App {
                 .constraints([Constraint::Min(0), Constraint::Length(1)].as_ref())
                 .split(frame.size());
 
+            let mut tables_entry_highlight_style = Style::default().fg(Color::Cyan);
             let mut tables_title_style = Style::default();
+            let mut table_entry_highlight_style = Style::default().fg(Color::Cyan);
             let mut table_title_style = Style::default();
-            let mut search_title_style = Style::default();
+            let mut search_style = Style::default();
             match self.focus {
                 Focus::Tables => {
-                    tables_title_style = tables_title_style.fg(Color::LightGreen);
+                    tables_entry_highlight_style = Style::default().fg(Color::LightGreen);
+                    tables_title_style = Style::default().fg(Color::LightGreen);
                 }
                 Focus::Table => {
-                    table_title_style = table_title_style.fg(Color::LightGreen);
+                    table_entry_highlight_style = Style::default().fg(Color::LightGreen);
+                    table_title_style = Style::default().fg(Color::LightGreen);
                 }
                 Focus::Search => {
-                    search_title_style = table_title_style.fg(Color::LightGreen);
+                    search_style = Style::default().fg(Color::LightGreen);
                 }
             }
 
@@ -207,7 +211,7 @@ impl App {
                             Span::raw(": navigate results || current query: "),
                         ];
                         if let Some(q) = self.search.value.as_ref() {
-                            nav.push(Span::styled(q, search_title_style));
+                            nav.push(Span::styled(q, search_style));
                         }
                         nav
                     }
@@ -240,11 +244,7 @@ impl App {
                         .title_style(tables_title_style)
                         .borders(Borders::ALL),
                 )
-                .highlight_style(
-                    Style::default()
-                        .fg(Color::Cyan)
-                        .add_modifier(Modifier::BOLD),
-                );
+                .highlight_style(tables_entry_highlight_style);
             let state = &mut self.tables.state;
             frame.render_stateful_widget(list, chunks[0], state);
             let num_table_rows = self.num_table_rows();

--- a/rql/src/app.rs
+++ b/rql/src/app.rs
@@ -161,7 +161,6 @@ impl App {
             let mut tables_title_style = Style::default();
             let mut table_entry_highlight_style = Style::default().fg(Color::Cyan);
             let mut table_title_style = Style::default();
-            let mut search_style = Style::default();
             match self.focus {
                 Focus::Tables => {
                     tables_entry_highlight_style = Style::default().fg(Color::LightGreen);
@@ -171,55 +170,10 @@ impl App {
                     table_entry_highlight_style = Style::default().fg(Color::LightGreen);
                     table_title_style = Style::default().fg(Color::LightGreen);
                 }
-                Focus::Search => {
-                    search_style = Style::default().fg(Color::LightGreen);
-                }
+                Focus::Search => (),
             }
 
-            let help = {
-                let no_style = Style::default();
-                let key_style = Style::default().fg(Color::LightCyan);
-                match self.focus {
-                    Focus::Tables | Focus::Table => {
-                        let mut nav = ["j", "k", "h", "l", "↓", "↑", "←", "→"]
-                            .iter()
-                            .zip(std::iter::repeat(Span::styled(",", no_style)))
-                            .map(|(s, sep)| [sep, Span::styled(*s, key_style)])
-                            .flatten()
-                            .skip(1)
-                            .collect::<Vec<_>>();
-                        nav.push(Span::raw(": navigate | "));
-                        nav.append(
-                            &mut ["q", "esc"]
-                                .iter()
-                                .zip(std::iter::repeat(Span::styled(",", no_style)))
-                                .map(|(s, sep)| [sep, Span::styled(*s, key_style)])
-                                .flatten()
-                                .skip(1)
-                                .collect::<Vec<_>>(),
-                        );
-                        nav.push(Span::raw(": back/quit | "));
-                        nav.push(Span::styled("/", key_style));
-                        nav.push(Span::raw(": search"));
-                        nav
-                    }
-                    Focus::Search => {
-                        let mut nav = vec![
-                            Span::styled("Esc", key_style),
-                            Span::raw(": exit search | "),
-                            Span::styled("Enter", key_style),
-                            Span::raw(": navigate results || current query: "),
-                        ];
-                        if let Some(q) = self.search.value.as_ref() {
-                            nav.push(Span::styled(q, search_style));
-                        }
-                        nav
-                    }
-                }
-            };
-            let help = text::Line::from(help);
-            let help = Paragraph::new(help);
-            frame.render_widget(help, chrome[1]);
+            frame.render_widget(self.render_help_nav(), chrome[1]);
             let chunks = Layout::default()
                 .direction(Direction::Horizontal)
                 .constraints(
@@ -392,6 +346,50 @@ impl App {
         }
 
         Tick::Continue
+    }
+
+    fn render_help_nav(&mut self) -> Paragraph {
+        let no_style = Style::default();
+        let key_style = Style::default().fg(Color::LightCyan);
+        let help = match self.focus {
+            Focus::Tables | Focus::Table => {
+                let mut nav = ["j", "k", "h", "l", "↓", "↑", "←", "→"]
+                    .iter()
+                    .zip(std::iter::repeat(Span::styled(",", no_style)))
+                    .map(|(s, sep)| [sep, Span::styled(*s, key_style)])
+                    .flatten()
+                    .skip(1)
+                    .collect::<Vec<_>>();
+                nav.push(Span::raw(": navigate | "));
+                nav.append(
+                    &mut ["q", "esc"]
+                        .iter()
+                        .zip(std::iter::repeat(Span::styled(",", no_style)))
+                        .map(|(s, sep)| [sep, Span::styled(*s, key_style)])
+                        .flatten()
+                        .skip(1)
+                        .collect::<Vec<_>>(),
+                );
+                nav.push(Span::raw(": back/quit | "));
+                nav.push(Span::styled("/", key_style));
+                nav.push(Span::raw(": search"));
+                nav
+            }
+            Focus::Search => {
+                let mut nav = vec![
+                    Span::styled("Esc", key_style),
+                    Span::raw(": exit search | "),
+                    Span::styled("Enter", key_style),
+                    Span::raw(": navigate results || current query: "),
+                ];
+                if let Some(q) = self.search.value.as_ref() {
+                    nav.push(Span::styled(q, Style::default().fg(Color::Green)));
+                }
+                nav
+            }
+        };
+
+        Paragraph::new(text::Line::from(help))
     }
 
     fn search(&mut self, k: KeyEvent) -> Option<Action> {

--- a/rql/src/app.rs
+++ b/rql/src/app.rs
@@ -425,10 +425,7 @@ impl App {
         }
     }
 
-    fn intersperse_keys<'a, 'b>(
-        keys: &'a [&'b str],
-        key_style: Style,
-    ) -> impl Iterator<Item = Span<'b>> + 'a {
+    fn intersperse_keys<'a>(keys: &'a [&'a str], key_style: Style) -> impl Iterator<Item = Span<'a>> + 'a {
         keys.iter()
             .zip(std::iter::repeat(Span::styled(",", Style::default())))
             .map(move |(s, sep)| [sep, Span::styled(*s, key_style)])

--- a/rql/src/app.rs
+++ b/rql/src/app.rs
@@ -55,7 +55,7 @@ impl Default for KeyBindSet {
                 (key(KeyCode::Down), TablesNext),
                 (key(KeyCode::Char('J')), TablesNext),
                 (key(KeyCode::Char('j')), TablesNext),
-                /// tablesprev
+                // tablesprev
                 (key(KeyCode::Up), TablesPrev),
                 (key(KeyCode::Char('K')), TablesPrev),
                 (key(KeyCode::Char('k')), TablesPrev),
@@ -94,6 +94,7 @@ impl Default for KeyBindSet {
                 (ctrl_key(KeyCode::Char('d')), PageDown),
                 (key(KeyCode::Char('/')), ChangeFocus(Focus::Search)),
                 (key(KeyCode::Char('?')), ChangeFocus(Focus::Search)),
+                (ctrl_key(KeyCode::Char('f')), ChangeFocus(Focus::Search)),
             ])
         });
         Self { bindings }
@@ -269,16 +270,20 @@ impl App {
             no_style
         };
         let help = match self.focus {
-            Focus::Tables | Focus::Table => {
+            Focus::Tables => {
                 Self::intersperse_keys(&["j", "k", "h", "l", "↓", "↑", "←", "→"], key_style)
                     .chain(vec![Span::raw(": navigate | ")])
                     .chain(Self::intersperse_keys(&["q", "esc"], key_style))
-                    .chain(vec![
-                        Span::raw(": back/quit | "),
-                        Span::styled("/", key_style),
-                        Span::raw(": "),
-                        Span::styled("search", search_style),
-                    ])
+                    .chain(vec![Span::raw(": back/quit")])
+                    .collect()
+            }
+            Focus::Table => {
+                Self::intersperse_keys(&["j", "k", "h", "l", "↓", "↑", "←", "→"], key_style)
+                    .chain(vec![Span::raw(": navigate | ")])
+                    .chain(Self::intersperse_keys(&["q", "esc"], key_style))
+                    .chain(vec![Span::raw(": back/quit | ")])
+                    .chain(Self::intersperse_keys(&["/", "C-f"], key_style))
+                    .chain(vec![Span::raw(": "), Span::styled("search", search_style)])
                     .collect()
             }
             Focus::Search => {

--- a/rql/src/app.rs
+++ b/rql/src/app.rs
@@ -179,9 +179,9 @@ impl App {
                 if self.focus == Focus::Search {
                     let mut nav = vec![
                         Span::styled("Esc", key_style),
-                        Span::raw(": Exit Search | "),
+                        Span::raw(": exit search | "),
                         Span::styled("Enter", key_style),
-                        Span::raw(": Navigate Results || Current Query: "),
+                        Span::raw(": navigate results || current query: "),
                     ];
                     if let Some(q) = self.search.value.as_ref() {
                         nav.push(Span::styled(q, search_title_style));
@@ -207,7 +207,7 @@ impl App {
                     );
                     nav.push(Span::raw(": back/quit | "));
                     nav.push(Span::styled("/", key_style));
-                    nav.push(Span::raw(": Search"));
+                    nav.push(Span::raw(": search"));
                     nav
                 }
             };

--- a/rql/src/dao.rs
+++ b/rql/src/dao.rs
@@ -363,7 +363,7 @@ impl Dao {
 
     async fn records(&self, schema: &TableSchema, req: GetRecords) -> Result<Vec<Record>> {
         let table_name = req.table_name.as_str();
-        let schema = self.table_schema(table_name).await?; // TODO: cache?
+        let schema = self.table_schema(table_name).await?;
         let mut conn = self.pool.acquire().await?;
         let limit = req.limit.map(|v| format!("limit {v}")).unwrap_or_default();
         let offset = req

--- a/rql/src/table.rs
+++ b/rql/src/table.rs
@@ -72,9 +72,9 @@ impl IndexedRecords {
 impl DbTable {
     pub fn new(dao: BlockingDao, name: String, search: Option<String>) -> Result<Self> {
         info!(name, "Building db table");
-        let count = dao.count(&name)?;
+        let count = dao.count(Count::new(&name).maybe_search(&search))?;
         let schema = dao.table_schema(&name)?;
-        let max_lens = dao.max_lens(&schema)?;
+        let max_lens = dao.max_lens(&schema, MaxLens::new(&name).maybe_search(&search))?;
         let max_lens: HashMap<TableColumn, usize> = schema
             .cols
             .iter()

--- a/rql/src/table.rs
+++ b/rql/src/table.rs
@@ -122,9 +122,13 @@ impl DbTable {
                 0
             };
             let limit = view_rows * 3;
-            let spec = GetRecords::new(&self.schema.name)
+            let mut spec = GetRecords::new(&self.schema.name)
                 .offset(offset)
                 .limit(limit);
+            if let Some(q) = self.search.value.as_ref() {
+                warn!("adding search to spec: {}", q);
+                spec = spec.search(q);
+            }
             let records = self.dao.records(&self.schema, spec)?;
             let irs = (offset..offset + limit)
                 .zip(records.into_iter())

--- a/rql/src/table.rs
+++ b/rql/src/table.rs
@@ -9,7 +9,7 @@ pub struct DbTable {
     pub pager: Pager,
     pub count: u64,
     pub indexed: IndexedRecords,
-    search: Search,
+    search: Option<String>,
 }
 
 #[derive(Default)]
@@ -70,7 +70,7 @@ impl IndexedRecords {
 }
 
 impl DbTable {
-    pub fn new(dao: BlockingDao, name: String, search: Search) -> Result<Self> {
+    pub fn new(dao: BlockingDao, name: String, search: Option<String>) -> Result<Self> {
         info!(name, "Building db table");
         let count = dao.count(&name)?;
         let schema = dao.table_schema(&name)?;
@@ -125,8 +125,7 @@ impl DbTable {
             let mut spec = GetRecords::new(&self.schema.name)
                 .offset(offset)
                 .limit(limit);
-            if let Some(q) = self.search.value.as_ref() {
-                warn!("adding search to spec: {}", q);
+            if let Some(q) = self.search.as_ref() {
                 spec = spec.search(q);
             }
             let records = self.dao.records(&self.schema, spec)?;


### PR DESCRIPTION
Even though most of the plumbing was laid, this ended up being larger than I'd have liked.

Major changes:
  - app input state machine was separated out. There's now a tick loop and a process action function.
  - Help rendering is broken out piecemeal and flexes based on focus
  - Focus highlighting was made more consistent.
  - DAO search query generation was created with tests.
  - searching: hit / when browsing a table, enter a query, then hit "enter" to browse or q to clear.
  - traced_test for log output when tests fail

Pieces I've left behind to keep this smaller:
  - schema caching: searches occur on each letter input, which polls schema to get column names
  - strong sqlite column typing: sqlite supports [many column names for the same types](https://www.sqlite.org/datatype3.html) (e.g. real vs double). I selected a few common ones, others won't work with searching for now.
  - clearer search focus: it isn't super obvious you're searching unless you know you did it. A pop-up or flashing cursor would be clearer.
  - search cursor: searching doesn't allow moving left/right in the search box.

Searching live
![image](https://github.com/collinvandyck/rust-learning/assets/4763746/fecd2b08-c6d0-403d-8511-66297fb2c0f0)

Browsing Results
![image](https://github.com/collinvandyck/rust-learning/assets/4763746/d97660fb-c96c-4b8e-9d03-e7de9b55fb29)
